### PR TITLE
Pass objects by constant reference instead of passing by value.

### DIFF
--- a/ResizableLib/ResizableFormView.cpp
+++ b/ResizableLib/ResizableFormView.cpp
@@ -83,7 +83,7 @@ void CResizableFormView::OnSize(UINT nType, int cx, int cy)
 {
 	CFormView::OnSize(nType, cx, cy);
 
-	CWnd* pParent = GetParentFrame();
+	const CWnd* pParent = GetParentFrame();
 
 	// hide size grip when parent is maximized
 	if (pParent->IsZoomed())
@@ -92,7 +92,7 @@ void CResizableFormView::OnSize(UINT nType, int cx, int cy)
 		ShowSizeGrip(&m_dwGripTempState, GHR_MAXIMIZED);
 
 	// hide size grip when there are scrollbars
-	CSize size = GetTotalSize();
+	const CSize size = GetTotalSize();
 	if ((cx < size.cx || cy < size.cy) && (m_nMapMode >= 0))
 		HideSizeGrip(&m_dwGripTempState, GHR_SCROLLBAR);
 	else
@@ -100,7 +100,6 @@ void CResizableFormView::OnSize(UINT nType, int cx, int cy)
 
 	// hide size grip when the parent frame window is not resizable
 	// or the form is not bottom-right aligned (e.g. there's a statusbar)
-	DWORD dwStyle = pParent->GetStyle();
 	CRect rect, rectChild;
 	GetWindowRect(rect);
 
@@ -116,7 +115,7 @@ void CResizableFormView::OnSize(UINT nType, int cx, int cy)
 			break;
 		}
 	}
-	if ((dwStyle & WS_THICKFRAME) && bCanResize)
+	if ((pParent->GetStyle() & WS_THICKFRAME) && bCanResize)
 		ShowSizeGrip(&m_dwGripTempState, GHR_ALIGNMENT);
 	else
 		HideSizeGrip(&m_dwGripTempState, GHR_ALIGNMENT);

--- a/ResizableLib/ResizableLayout.cpp
+++ b/ResizableLib/ResizableLayout.cpp
@@ -205,7 +205,7 @@ void CResizableLayout::ArrangeLayout() const
 	// common vars
 	UINT uFlags;
 	CRect rectParent, rectChild;
-	INT_PTR count = m_listLayout.GetCount() + m_listLayoutCB.GetCount();
+	const INT_PTR count = m_listLayout.GetCount() + m_listLayoutCB.GetCount();
 
 	if (count <= 0)
 		return;
@@ -293,7 +293,7 @@ void CResizableLayout::ClipChildWindow(const LAYOUTINFO& layout,
 	}
 
 	// get the clipping property
-	BOOL bClipping = layout.properties.bAskClipping ?
+	const BOOL bClipping = layout.properties.bAskClipping ?
 		LikesClipping(layout) : layout.properties.bCachedLikesClipping;
 
 	// modify region accordingly
@@ -317,7 +317,7 @@ void CResizableLayout::ClipChildWindow(const LAYOUTINFO& layout,
  */
 void CResizableLayout::GetClippingRegion(CRgn* pRegion) const
 {
-	CWnd* pWnd = GetResizableWnd();
+	const CWnd* pWnd = GetResizableWnd();
 
 	// System's default clipping area is screen's size,
 	// not enough for max track size, for example:
@@ -334,26 +334,22 @@ void CResizableLayout::GetClippingRegion(CRgn* pRegion) const
 	pRegion->CreateRectRgnIndirect(&rect);
 
 	// clip only anchored controls
-	LAYOUTINFO layout;
-	POSITION pos = m_listLayout.GetHeadPosition();
-	while (pos != NULL)
+
+	for (POSITION pos = m_listLayout.GetHeadPosition(); pos != NULL;)
 	{
 		// get layout info
-		layout = m_listLayout.GetNext(pos);
+		LAYOUTINFO layout = m_listLayout.GetNext(pos);
 
 		if (::IsWindowVisible(layout.hWnd))
 			ClipChildWindow(layout, pRegion);
 	}
-	pos = m_listLayoutCB.GetHeadPosition();
-	while (pos != NULL)
+	
+	for (POSITION pos = m_listLayoutCB.GetHeadPosition(); pos != NULL;)
 	{
 		// get layout info
-		layout = m_listLayoutCB.GetNext(pos);
+		LAYOUTINFO layout = m_listLayoutCB.GetNext(pos);
 		// request data
-		if (!ArrangeLayoutCallback(layout))
-			continue;
-
-		if (::IsWindowVisible(layout.hWnd))
+		if (ArrangeLayoutCallback(layout) && ::IsWindowVisible(layout.hWnd))
 			ClipChildWindow(layout, pRegion);
 	}
 //! @todo Has XP changed this??? It doesn't seem correct anymore!
@@ -405,8 +401,8 @@ BOOL CResizableLayout::ClipChildren(const CDC* pDC, BOOL bUndo)
 	}
 #endif
 
-	HDC hDC = pDC->GetSafeHdc();
-	HWND hWnd = GetResizableWnd()->GetSafeHwnd();
+	const HDC hDC = pDC->GetSafeHdc();
+	const HWND hWnd = GetResizableWnd()->GetSafeHwnd();
 
 	// Some controls (such as transparent toolbars and standard controls
 	// with XP theme enabled) send a WM_ERASEBKGND msg to the parent
@@ -490,8 +486,8 @@ BOOL CResizableLayout::NeedsRefresh(const LAYOUTINFO& layout,
 			return refresh.bNeedsRefresh;
 	}
 
-	int nDiffWidth = (rectNew.Width() - rectOld.Width());
-	int nDiffHeight = (rectNew.Height() - rectOld.Height());
+	const int nDiffWidth = (rectNew.Width() - rectOld.Width());
+	const int nDiffHeight = (rectNew.Height() - rectOld.Height());
 
 	// is the same size?
 	if (nDiffWidth == 0 && nDiffHeight == 0)
@@ -543,9 +539,7 @@ BOOL CResizableLayout::NeedsRefresh(const LAYOUTINFO& layout,
 
 	// window classes that don't redraw client area correctly
 	// when the hor scroll pos changes due to a resizing
-	BOOL bHScroll = FALSE;
-	if (0 == lstrcmp(layout.sWndClass, WC_LISTBOX))
-		bHScroll = TRUE;
+	const BOOL bHScroll = (0 == lstrcmp(layout.sWndClass, WC_LISTBOX));
 
 	// fix for horizontally scrollable windows, if wider
 	if (bHScroll && (nDiffWidth > 0))
@@ -665,7 +659,7 @@ BOOL CResizableLayout::LikesClipping(const LAYOUTINFO& layout) const
 void CResizableLayout::CalcNewChildPosition(const LAYOUTINFO& layout,
 						const CRect &rectParent, CRect &rectChild, UINT *lpFlags) const
 {
-	CWnd* pParent = GetResizableWnd();
+	const CWnd* pParent = GetResizableWnd();
 
 	::GetWindowRect(layout.hWnd, &rectChild);
 	::MapWindowPoints(NULL, pParent->m_hWnd, (LPPOINT)&rectChild, 2);

--- a/ResizableLib/ResizableLib.vcxproj
+++ b/ResizableLib/ResizableLib.vcxproj
@@ -400,26 +400,8 @@
     </Bscmake>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="ResizableComboBox.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Static Unicode|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Static|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Unicode|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Static Unicode|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Static|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Unicode|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="ResizableComboLBox.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Static Unicode|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Static|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Unicode|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Static Unicode|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Static|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Unicode|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="ResizableComboBox.cpp" />
+    <ClCompile Include="ResizableComboLBox.cpp" />
     <ClCompile Include="ResizableDialog.cpp" />
     <ClCompile Include="ResizableFormView.cpp" />
     <ClCompile Include="ResizableFrame.cpp" />
@@ -451,26 +433,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Docs\refman.h" />
-    <CustomBuild Include="ResizableComboBox.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Static Unicode|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Unicode|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Static Unicode|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Unicode|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-    </CustomBuild>
-    <CustomBuild Include="ResizableComboLBox.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Static Unicode|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Unicode|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Static Unicode|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Unicode|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-    </CustomBuild>
+    <ClInclude Include="ResizableComboBox.h" />
+    <ClInclude Include="ResizableComboLBox.h" />
     <ClInclude Include="ResizableDialog.h" />
     <ClInclude Include="ResizableFormView.h" />
     <ClInclude Include="ResizableFrame.h" />

--- a/ResizableLib/ResizableMinMax.cpp
+++ b/ResizableLib/ResizableMinMax.cpp
@@ -59,7 +59,7 @@ void CResizableMinMax::MinMaxInfo(LPMINMAXINFO lpMMI) const
 	}
 }
 
-void CResizableMinMax::ChainMinMaxInfo(LPMINMAXINFO lpMMI, CWnd* pParentFrame, CWnd* pWnd)
+void CResizableMinMax::ChainMinMaxInfo(LPMINMAXINFO lpMMI, CWnd* pParentFrame, const CWnd* pWnd)
 {
 	// get the extra size from child to parent
 	CRect rectClient, rectWnd;
@@ -69,12 +69,12 @@ void CResizableMinMax::ChainMinMaxInfo(LPMINMAXINFO lpMMI, CWnd* pParentFrame, C
 		pParentFrame->GetWindowRect(rectWnd);
 	pParentFrame->RepositionBars(0, 0xFFFF,
 		AFX_IDW_PANE_FIRST, CWnd::reposQuery, rectClient);
-	CSize sizeExtra = rectWnd.Size() - rectClient.Size();
+	const CSize sizeExtra = rectWnd.Size() - rectClient.Size();
 
 	ChainMinMaxInfo(lpMMI, pWnd->GetSafeHwnd(), sizeExtra);
 }
 
-void CResizableMinMax::ChainMinMaxInfo(LPMINMAXINFO lpMMI, HWND hWndChild, CSize sizeExtra)
+void CResizableMinMax::ChainMinMaxInfo(LPMINMAXINFO lpMMI, HWND hWndChild, const CSize& sizeExtra)
 {
 	// ask the child window for track size
 	MINMAXINFO mmiChild = *lpMMI;
@@ -106,7 +106,7 @@ void CResizableMinMax::ChainMinMaxInfo(LPMINMAXINFO lpMMI, HWND hWndChild, CSize
 	}
 }
 
-BOOL CResizableMinMax::CalcSizeExtra(HWND /*hWndChild*/, CSize /*sizeChild*/, CSize& /*sizeExtra*/)
+BOOL CResizableMinMax::CalcSizeExtra(HWND /*hWndChild*/, const CSize& /*sizeChild*/, CSize& /*sizeExtra*/)
 {
 	// should be overridden if you use ChainMinMaxInfoCB
 	ASSERT(FALSE);

--- a/ResizableLib/ResizableMinMax.h
+++ b/ResizableLib/ResizableMinMax.h
@@ -53,18 +53,18 @@ public:
 
 protected:
 	void MinMaxInfo(LPMINMAXINFO lpMMI) const;
-	static void ChainMinMaxInfo(LPMINMAXINFO lpMMI, CWnd* pParentFrame, CWnd* pWnd);
+	static void ChainMinMaxInfo(LPMINMAXINFO lpMMI, CWnd* pParentFrame, const CWnd* pWnd);
 
-	static void ChainMinMaxInfo(LPMINMAXINFO lpMMI, HWND hWndChild, CSize sizeExtra);
+	static void ChainMinMaxInfo(LPMINMAXINFO lpMMI, HWND hWndChild, const CSize& sizeExtra);
 
-	static void ChainMinMaxInfo(LPMINMAXINFO lpMMI, CWnd* pParentWnd, UINT nID, CSize sizeExtra)
+	static void ChainMinMaxInfo(LPMINMAXINFO lpMMI, const CWnd* pParentWnd, UINT nID, const CSize& sizeExtra)
 	{
 		ChainMinMaxInfo(lpMMI,
 			::GetDlgItem(pParentWnd->GetSafeHwnd(), nID), sizeExtra);
 	}
 
 	void ChainMinMaxInfoCB(LPMINMAXINFO lpMMI, HWND hWndChild);
-	virtual BOOL CalcSizeExtra(HWND hWndChild, CSize sizeChild, CSize& sizeExtra);
+	virtual BOOL CalcSizeExtra(HWND hWndChild, const CSize& sizeChild, CSize& sizeExtra);
 
 	void ResetAllRects();
 

--- a/ResizableLib/ResizableSheet.cpp
+++ b/ResizableLib/ResizableSheet.cpp
@@ -323,7 +323,7 @@ BOOL CResizableSheet::OnEraseBkgnd(CDC* pDC)
 	return bRet;
 }
 
-BOOL CResizableSheet::CalcSizeExtra(HWND /*hWndChild*/, CSize sizeChild, CSize &sizeExtra)
+BOOL CResizableSheet::CalcSizeExtra(HWND /*hWndChild*/, const CSize& sizeChild, CSize& sizeExtra)
 {
 	CTabCtrl* pTab = GetTabControl();
 	if (!pTab)
@@ -368,11 +368,10 @@ void CResizableSheet::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	MinMaxInfo(lpMMI);
 
-	CTabCtrl* pTab = GetTabControl();
-	if (!pTab)
+	if (!GetTabControl())
 		return;
 
-	int nCount = GetPageCount();
+	const int nCount = GetPageCount();
 	for (int idx = 0; idx < nCount; ++idx)
 	{
 		if (IsWizard())	// wizard mode
@@ -402,7 +401,7 @@ int CResizableSheet::GetMinWidth()
 	// search for leftmost and rightmost button margins
 	for (int i = 0; i < 7; i++)
 	{
-		CWnd* pWnd = GetDlgItem(_propButtons[i]);
+		const CWnd* pWnd = GetDlgItem(_propButtons[i]);
 		// exclude not present or hidden buttons
 		if (pWnd == NULL || !(pWnd->GetStyle() & WS_VISIBLE))
 			continue;
@@ -411,8 +410,8 @@ int CResizableSheet::GetMinWidth()
 		// of the parent window (negative value)
 		pWnd->GetWindowRect(&rectWnd);
 		::MapWindowPoints(NULL, m_hWnd, (LPPOINT)&rectWnd, 2);
-		int left = rectSheet.right - rectWnd.left;
-		int right = rectSheet.right - rectWnd.right;
+		const int left = rectSheet.right - rectWnd.left;
+		const int right = rectSheet.right - rectWnd.right;
 
 		if (left > max)
 			max = left;
@@ -421,7 +420,7 @@ int CResizableSheet::GetMinWidth()
 	}
 
 	// sizing border width
-	int border = GetSystemMetrics(SM_CXSIZEFRAME);
+	const int border = GetSystemMetrics(SM_CXSIZEFRAME);
 	
 	// compute total width
 	return max + min + 2*border;

--- a/ResizableLib/ResizableSheet.h
+++ b/ResizableLib/ResizableSheet.h
@@ -101,7 +101,7 @@ protected:
 
 // Generated message map functions
 protected:
-	virtual BOOL CalcSizeExtra(HWND hWndChild, CSize sizeChild, CSize& sizeExtra);
+	virtual BOOL CalcSizeExtra(HWND hWndChild, const CSize& sizeChild, CSize& sizeExtra);
 	virtual BOOL ArrangeLayoutCallback(LAYOUTINFO& layout) const;
 	//{{AFX_MSG(CResizableSheet)
 	afx_msg void OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI);

--- a/ResizableLib/ResizableSheetEx.cpp
+++ b/ResizableLib/ResizableSheetEx.cpp
@@ -112,7 +112,7 @@ BOOL CResizableSheetEx::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 
 BOOL CResizableSheetEx::OnInitDialog() 
 {
-	BOOL bResult = CPropertySheetEx::OnInitDialog();
+	const BOOL bResult = CPropertySheetEx::OnInitDialog();
 	
 	// initialize layout
 	PresetLayout();
@@ -410,7 +410,7 @@ BOOL CResizableSheetEx::OnEraseBkgnd(CDC* pDC)
 	return bRet;
 }
 
-BOOL CResizableSheetEx::CalcSizeExtra(HWND /*hWndChild*/, CSize sizeChild, CSize &sizeExtra)
+BOOL CResizableSheetEx::CalcSizeExtra(HWND /*hWndChild*/, const CSize& sizeChild, CSize& sizeExtra)
 {
 	CTabCtrl* pTab = GetTabControl();
 	if (!pTab)
@@ -455,11 +455,10 @@ void CResizableSheetEx::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	MinMaxInfo(lpMMI);
 
-	CTabCtrl* pTab = GetTabControl();
-	if (!pTab)
+	if (!GetTabControl())
 		return;
 
-	int nCount = GetPageCount();
+	const int nCount = GetPageCount();
 	for (int idx = 0; idx < nCount; ++idx)
 	{
 		if (IsWizard())	// wizard mode
@@ -501,7 +500,7 @@ void CResizableSheetEx::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 
 void CResizableSheetEx::GetHeaderRect(LPRECT lpRect)
 {
-	CWnd* pWizLineHdr = GetDlgItem(ID_WIZLINEHDR);
+	const CWnd* pWizLineHdr = GetDlgItem(ID_WIZLINEHDR);
 	if (pWizLineHdr != NULL && pWizLineHdr->IsWindowVisible())
 	{
 		pWizLineHdr->GetWindowRect(lpRect);
@@ -523,7 +522,7 @@ int CResizableSheetEx::GetMinWidth()
 	// search for leftmost and rightmost button margins
 	for (int i = 0; i < 7; i++)
 	{
-		CWnd* pWnd = GetDlgItem(_propButtons[i]);
+		const CWnd* pWnd = GetDlgItem(_propButtons[i]);
 		// exclude not present or hidden buttons
 		if (pWnd == NULL || !(pWnd->GetStyle() & WS_VISIBLE))
 			continue;
@@ -532,8 +531,8 @@ int CResizableSheetEx::GetMinWidth()
 		// of the parent window (negative value)
 		pWnd->GetWindowRect(&rectWnd);
 		::MapWindowPoints(NULL, m_hWnd, (LPPOINT)&rectWnd, 2);
-		int left = rectSheet.right - rectWnd.left;
-		int right = rectSheet.right - rectWnd.right;
+		const int left = rectSheet.right - rectWnd.left;
+		const int right = rectSheet.right - rectWnd.right;
 		
 		if (left > max)
 			max = left;
@@ -542,7 +541,7 @@ int CResizableSheetEx::GetMinWidth()
 	}
 
 	// sizing border width
-	int border = GetSystemMetrics(SM_CXSIZEFRAME);
+	const int border = GetSystemMetrics(SM_CXSIZEFRAME);
 	
 	// compute total width
 	return max + min + 2*border;

--- a/ResizableLib/ResizableSheetEx.h
+++ b/ResizableLib/ResizableSheetEx.h
@@ -109,7 +109,7 @@ protected:
 // Generated message map functions
 protected:
 	void GetHeaderRect(LPRECT lpRect);
-	virtual BOOL CalcSizeExtra(HWND hWndChild, CSize sizeChild, CSize& sizeExtra);
+	virtual BOOL CalcSizeExtra(HWND hWndChild, const CSize& sizeChild, CSize& sizeExtra);
 	virtual BOOL ArrangeLayoutCallback(LAYOUTINFO& layout) const;
 	//{{AFX_MSG(CResizableSheetEx)
 	afx_msg void OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI);

--- a/ResizableLib/ResizableSheetState.cpp
+++ b/ResizableLib/ResizableSheetState.cpp
@@ -55,21 +55,21 @@ BOOL CResizableSheetState::SavePage(LPCTSTR pszName)
 	// saves active page index, or the initial page if problems
 	// cannot use GetActivePage, because it always fails
 
-	CPropertySheet* pSheet = DYNAMIC_DOWNCAST(CPropertySheet, GetResizableWnd());
+	const CPropertySheet* pSheet = DYNAMIC_DOWNCAST(CPropertySheet, GetResizableWnd());
 	if (pSheet == NULL)
 		return FALSE;
 
 	int page = pSheet->m_psh.nStartPage;
-	CTabCtrl *pTab = pSheet->GetTabControl();
+	const CTabCtrl *pTab = pSheet->GetTabControl();
 	if (pTab != NULL) 
 		page = pTab->GetCurSel();
 	if (page < 0)
 		page = pSheet->m_psh.nStartPage;
 
 	CString data;
-	_itot_s(page, data.GetBuffer(10), 10, 10);
-	CString id = CString(pszName) + ACTIVEPAGE_ENT;
-	return WriteState(id, data);
+	data.Format(_T("%i"), page);
+
+	return WriteState(CString(pszName) + ACTIVEPAGE_ENT, data);
 }
 
 /*!
@@ -84,14 +84,11 @@ BOOL CResizableSheetState::LoadPage(LPCTSTR pszName)
 {
 	// restore active page, zero (the first) if not found
 
-	CString data, id;
-	id = CString(pszName) + ACTIVEPAGE_ENT;
-	if (!ReadState(id, data))
+	CString data;
+	if (!ReadState(CString(pszName) + ACTIVEPAGE_ENT, data))
 		return FALSE;
 	
-	int page = _ttoi(data);
 	CPropertySheet* pSheet = DYNAMIC_DOWNCAST(CPropertySheet, GetResizableWnd());
-	if (pSheet != NULL)
-		return pSheet->SetActivePage(page);
-	return FALSE;
+
+	return (pSheet != NULL) && pSheet->SetActivePage(_ttoi(data));
 }

--- a/ResizableLib/ResizableSplitterWnd.cpp
+++ b/ResizableLib/ResizableSplitterWnd.cpp
@@ -51,14 +51,14 @@ void CResizableSplitterWnd::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 	if ((GetStyle() & SPLS_DYNAMIC_SPLIT) &&
 		GetRowCount() == 1 && GetColumnCount() == 1)
 	{
-		CWnd* pPane = GetActivePane();
+		const CWnd* pPane = GetActivePane();
 		if (pPane != NULL)
 		{
 			// get the extra size from child to parent
 			CRect rectClient, rectWnd;
 			GetWindowRect(rectWnd);
 			pPane->GetWindowRect(rectClient);
-			CSize sizeExtra = rectWnd.Size() - rectClient.Size();
+			const CSize sizeExtra = rectWnd.Size() - rectClient.Size();
 
 			ChainMinMaxInfo(lpMMI, pPane->m_hWnd, sizeExtra);
 		}
@@ -75,7 +75,7 @@ void CResizableSplitterWnd::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 			int max = LONG_MAX;
 			for (int row = 0; row < m_nRows; ++row)
 			{
-				CWnd* pWnd = GetPane(row, col);
+				const CWnd* pWnd = GetPane(row, col);
 				// ask the child window for track size
 				MINMAXINFO mmiChild = *lpMMI;
 				mmiChild.ptMinTrackSize.x = 0;
@@ -98,7 +98,7 @@ void CResizableSplitterWnd::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 			int max = LONG_MAX;
 			for (int col = 0; col < m_nCols; ++col)
 			{
-				CWnd* pWnd = GetPane(row, col);
+				const CWnd* pWnd = GetPane(row, col);
 				// ask the child window for track size
 				MINMAXINFO mmiChild = *lpMMI;
 				mmiChild.ptMinTrackSize.y = 0;

--- a/ResizableLib/ResizableWndState.cpp
+++ b/ResizableLib/ResizableWndState.cpp
@@ -57,15 +57,15 @@ CResizableWndState::~CResizableWndState()
  */
 BOOL CResizableWndState::SaveWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 {
-	CString data, id;
 	WINDOWPLACEMENT wp = {sizeof(WINDOWPLACEMENT)};
 
 	if (!GetResizableWnd()->GetWindowPlacement(&wp))
 		return FALSE;
 
 	// use workspace coordinates
-	RECT& rc = wp.rcNormalPosition;
+	const RECT& rc = wp.rcNormalPosition;
 
+	CString data;
 	if (bRectOnly)	// save size/pos only (normal state)
 	{
 		data.Format(PLACEMENT_FMT, rc.left, rc.top,
@@ -78,8 +78,7 @@ BOOL CResizableWndState::SaveWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 			wp.ptMinPosition.x, wp.ptMinPosition.y);
 	}
 
-	id = CString(pszName) + PLACEMENT_ENT;
-	return WriteState(id, data);
+	return WriteState(CString(pszName) + PLACEMENT_ENT, data);
 }
 
 /*!
@@ -97,11 +96,10 @@ BOOL CResizableWndState::SaveWindowRect(LPCTSTR pszName, BOOL bRectOnly)
  */
 BOOL CResizableWndState::LoadWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 {
-	CString data, id;
+	CString data;
 	WINDOWPLACEMENT wp = {sizeof(WINDOWPLACEMENT)};
 
-	id = CString(pszName) + PLACEMENT_ENT;
-	if (!ReadState(id, data))	// never saved before
+	if (!ReadState(CString(pszName) + PLACEMENT_ENT, data))	// never saved before
 		return FALSE;
 
 	if (!GetResizableWnd()->GetWindowPlacement(&wp))


### PR DESCRIPTION
Local variables: reduce scope, eliminate intermediates, add 'const' qualifiers.
Reorder statements in case of an early return.
Use CString.Format instead of conversion function.
Minor cleaning in .vcxpoj file: default settings for CResizable(L)Box.*