### PR TITLE
Replace init_seg(lib) with a static initializer

### DIFF
--- a/ResizableLib/ResizableState.cpp
+++ b/ResizableLib/ResizableState.cpp
@@ -27,6 +27,8 @@ static char THIS_FILE[]=__FILE__;
 #define new DEBUG_NEW
 #endif
 
+LPCTSTR CResizableState::m_sDefaultStorePath = _T("ResizableState");
+
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
@@ -40,11 +42,6 @@ CResizableState::~CResizableState()
 {
 
 }
-
-// static intializer must be called before user code
-#pragma warning(disable:4073)
-#pragma init_seg(lib)
-CString CResizableState::m_sDefaultStorePath(_T("ResizableState"));
 
 /*!
  *  Static function to set the default path used to store state information.

--- a/ResizableLib/ResizableState.h
+++ b/ResizableLib/ResizableState.h
@@ -38,7 +38,7 @@
  */
 class CResizableState
 {
-	static CString m_sDefaultStorePath;
+	static LPCTSTR m_sDefaultStorePath;
 	CString m_sStorePath;
 
 protected:


### PR DESCRIPTION
CRT heap debugger was reporting an unreleased block on program exit.
It could have been a false positive, but replacing an object with a pointer would exclude  construction/destruction code, because the static pointer would be initialized at compile time.