### PR TITLE
Fix a bug, and clear a debug assert

### DIFF
--- a/ResizableLib/ResizableFormView.cpp
+++ b/ResizableLib/ResizableFormView.cpp
@@ -128,16 +128,16 @@ void CResizableFormView::OnSize(UINT nType, int cx, int cy)
 void CResizableFormView::GetTotalClientRect(LPRECT lpRect) const
 {
 	GetClientRect(lpRect);
+	// done, if there are no active scrollbars
+	if (!(GetStyle() & (WS_HSCROLL | WS_VSCROLL)))
+		return;
 
 	// get dialog template's size
 	// (this is set in CFormView::Create)
 	CSize sizeTotal, sizePage, sizeLine;
-	int nMapMode = 0;
+	int nMapMode;
 	GetDeviceScrollSizes(nMapMode, sizeTotal, sizePage, sizeLine);
-
-	// otherwise, give the correct size if scrollbars active
-
-	if (nMapMode < 0)	// scrollbars disabled
+	if (nMapMode <= 0)	// scrollbars disabled (invalid mapping mode)
 		return;
 
 	// enlarge reported client area when needed

--- a/ResizableLib/ResizableLayout.cpp
+++ b/ResizableLib/ResizableLayout.cpp
@@ -126,7 +126,7 @@ void CResizableLayout::AddAllOtherAnchors(ANCHOR anchorTopLeft, ANCHOR anchorBot
 	for (; hWnd != NULL; hWnd = ::GetNextWindow(hWnd, GW_HWNDNEXT))
 	{
 		TCHAR szClassName[32];
-		if (::GetClassName(hWnd, szClassName, sizeof(szClassName)))
+		if (::GetClassName(hWnd, szClassName, _countof(szClassName)))
 		{
 			if (lstrcmp(szClassName, WC_SCROLLBAR) == 0)
 			{


### PR DESCRIPTION
1. Fix a dangerous bug in CResizableLayout::AddAllOtherAnchors
`::GetClassName(hWnd, szClassName, _countof(szClassName))`
The third parameter is a character count, not a byte count.
In Unicode builds `sizeof` would give twice the length of the name buffer; and access violations might be expected; especially with a small buffer.
Not necessarily, but to make the code suitable for prehistoric VS versions,  `_countof(x)` might be replaced with `sizeof(x)/sizeof(x[0])`.

2. Clear a rare debug assert in CResizableFormView::GetTotalClientRect
A trivial sequence "remove anchor - set window placement - add anchor" was fine in the first pass, but fired a debug asserts afterwards. The problem was in an attempted access to a non-existent scrollbar. An early check and return fixed this.
`GetDeviceScrollSizes` treats all non-positive mapping modes as invalid, and the condition `nMapMode < 0` was changed accordingly.