### PR TITLE
Move some inline functions from the header to the cpp file because of…

### DIFF
--- a/ResizableLib/ResizableDialog.cpp
+++ b/ResizableLib/ResizableDialog.cpp
@@ -141,6 +141,12 @@ void CResizableDialog::EnableSaveRestore(LPCTSTR pszSection, BOOL bRectOnly)
 	LoadWindowRect(pszSection, bRectOnly);
 }
 
+/*virtual*/ CWnd* CResizableDialog::GetResizableWnd() const
+{
+  // make the layout know its parent window
+  return CWnd::FromHandle(m_hWnd);
+};
+
 BOOL CResizableDialog::OnEraseBkgnd(CDC* pDC) 
 {
 	ClipChildren(pDC, FALSE);

--- a/ResizableLib/ResizableDialog.h
+++ b/ResizableLib/ResizableDialog.h
@@ -76,11 +76,7 @@ protected:
 	// section to use in app's profile
 	void EnableSaveRestore(LPCTSTR pszSection, BOOL bRectOnly = FALSE);
 
-	virtual CWnd* GetResizableWnd() const
-	{
-		// make the layout know its parent window
-		return CWnd::FromHandle(m_hWnd);
-	};
+	virtual CWnd* GetResizableWnd() const;
 
 // Generated message map functions
 protected:

--- a/ResizableLib/ResizableLayout.cpp
+++ b/ResizableLib/ResizableLayout.cpp
@@ -103,6 +103,23 @@ void CResizableLayout::AddAnchor(HWND hWnd, ANCHOR anchorTopLeft, ANCHOR anchorB
 	m_mapLayout.SetAt(hWnd, pos);
 }
 
+void CResizableLayout::AddAnchor(HWND hWnd, ANCHOR anchorTopLeft)
+{
+  AddAnchor(hWnd, anchorTopLeft, anchorTopLeft);
+}
+
+void CResizableLayout::AddAnchor(UINT nID, ANCHOR anchorTopLeft, ANCHOR anchorBottomRight)
+{
+  AddAnchor(::GetDlgItem(GetResizableWnd()->GetSafeHwnd(), nID),
+    anchorTopLeft, anchorBottomRight);
+}
+
+void CResizableLayout::AddAnchor(UINT nID, ANCHOR anchorTopLeft)
+{
+  AddAnchor(::GetDlgItem(GetResizableWnd()->GetSafeHwnd(), nID),
+    anchorTopLeft, anchorTopLeft);
+}
+
 /*!
  *  This function adds all the controls not yet added to the layout manager
  *  and sets anchor points for its top-left and bottom-right corners.
@@ -141,6 +158,21 @@ void CResizableLayout::AddAllOtherAnchors(ANCHOR anchorTopLeft, ANCHOR anchorBot
 		if (!m_mapLayout.Lookup(hWnd, pos))
 			AddAnchor(hWnd, anchorTopLeft, anchorBottomRight);
 	}
+}
+
+void CResizableLayout::AddAllOtherAnchors(ANCHOR anchor)
+{
+	AddAllOtherAnchors(anchor, anchor);
+}
+
+void CResizableLayout::AddAllOtherAnchors()
+{
+  AddAllOtherAnchors(TOP_LEFT);
+}
+
+BOOL CResizableLayout::RemoveAnchor(UINT nID)
+{
+  return RemoveAnchor(::GetDlgItem(GetResizableWnd()->GetSafeHwnd(), nID));
 }
 
 /*!

--- a/ResizableLib/ResizableLayout.h
+++ b/ResizableLib/ResizableLayout.h
@@ -186,37 +186,21 @@ protected:
 	//! @brief Add anchor points for the specified control to the layout
 	void AddAnchor(HWND hWnd, ANCHOR anchorTopLeft, ANCHOR anchorBottomRight);
 
-	void AddAnchor(HWND hWnd, ANCHOR anchorTopLeft)
-	{
-		AddAnchor(hWnd, anchorTopLeft, anchorTopLeft);
-	}
+	void AddAnchor(HWND hWnd, ANCHOR anchorTopLeft);
 
-	void AddAnchor(UINT nID, ANCHOR anchorTopLeft, ANCHOR anchorBottomRight)
-	{
-		AddAnchor(::GetDlgItem(GetResizableWnd()->GetSafeHwnd(), nID),
-			anchorTopLeft, anchorBottomRight);
-	}
+	void AddAnchor(UINT nID, ANCHOR anchorTopLeft, ANCHOR anchorBottomRight);
 
-	void AddAnchor(UINT nID, ANCHOR anchorTopLeft)
-	{
-		AddAnchor(::GetDlgItem(GetResizableWnd()->GetSafeHwnd(), nID),
-			anchorTopLeft, anchorTopLeft);
-	}
+	void AddAnchor(UINT nID, ANCHOR anchorTopLeft);
 	//@}
 
 	//@{
 	//! @brief Add anchor points for all the remaining controls to the layout
 	void AddAllOtherAnchors(ANCHOR anchorTopLeft, ANCHOR anchorBottomRight);
 	
-	void AddAllOtherAnchors(ANCHOR anchor)
-	{
-		AddAllOtherAnchors(anchor, anchor);
-	}
+	void AddAllOtherAnchors(ANCHOR anchor);
 
-	void AddAllOtherAnchors()
-	{
-		AddAllOtherAnchors(TOP_LEFT);
-	}
+
+	void AddAllOtherAnchors();
 	//@}
 
 	//! @brief Add a callback slot to the layout for dynamic controls or anchor points
@@ -266,10 +250,7 @@ protected:
 		return m_mapLayout.RemoveKey(hWnd);
 	}
 
-	BOOL RemoveAnchor(UINT nID)
-	{
-		return RemoveAnchor(::GetDlgItem(GetResizableWnd()->GetSafeHwnd(), nID));
-	}
+	BOOL RemoveAnchor(UINT nID);
 	//@}
 
 	//! @brief Reset the layout content


### PR DESCRIPTION
… linker errors when using ResizableLib as dll, see Issue #17 https://github.com/ppescher/resizablelib/issues/17