### PR TITLE
Partial optimization of code

### DIFF
--- a/ResizableComboBox/Demo.sln
+++ b/ResizableComboBox/Demo.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ResizableLib", "..\ResizableLib\ResizableLib.vcxproj", "{C176053F-C799-4BF4-ABFA-125A4192CEB9}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Demo", "Demo.vcxproj", "{E90C0521-E036-49C5-BC3E-F27276C73726}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ResizableLib", "..\ResizableLib\ResizableLib.vcxproj", "{C176053F-C799-4BF4-ABFA-125A4192CEB9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ResizableLib/ResizableComboLBox.cpp
+++ b/ResizableLib/ResizableComboLBox.cpp
@@ -321,7 +321,7 @@ void CResizableComboLBox::ApplyLimitsToPos(WINDOWPOS* lpwndpos)
 
 	// back to window rect
 	rect = CRect(0, 0, 1, sizeClient.cy);
-	DWORD dwStyle = GetStyle();
+	const DWORD dwStyle = GetStyle();
 	::AdjustWindowRectEx(&rect, dwStyle, FALSE, GetExStyle());
 	lpwndpos->cy = rect.Height();
 	if (dwStyle & WS_HSCROLL)

--- a/ResizableLib/ResizableDialog.cpp
+++ b/ResizableLib/ResizableDialog.cpp
@@ -82,14 +82,15 @@ BOOL CResizableDialog::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 	if (!CreateSizeGrip(!bChild))
 		return FALSE;
 
+	// Moved from behind if (!bChild) because user could resize the dialog smaller as in resource defined and that causes some static text to be clipped or dissapear.
+	MakeResizable(lpCreateStruct);
+
 	if (!bChild)
 	{
 		// set the initial size as the min track size
 		SetMinTrackSize(CSize(lpCreateStruct->cx, lpCreateStruct->cy));
 	}
 	
-	MakeResizable(lpCreateStruct);
-
 	return TRUE;
 }
 

--- a/ResizableLib/ResizableLayout.cpp
+++ b/ResizableLib/ResizableLayout.cpp
@@ -689,7 +689,8 @@ void CResizableLayout::CalcNewChildPosition(const LAYOUTINFO& layout,
 		NeedsRefresh(layout, rectChild, rectNew) : layout.properties.bCachedNeedsRefresh;
 
 	// set flags
-	if (lpFlags) {
+	if (lpFlags)
+	{
 		*lpFlags = SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREPOSITION;
 		if (bRefresh)
 			*lpFlags |= SWP_NOCOPYBITS;


### PR DESCRIPTION
While figuring out implication of the PR #19, it was found that certain parts of the library could be improved. The code in this PR should be slightly faster and smaller (1 KB was shaved off from an application).

1. Probably you should merge @Blonder's PR before this one to give him credits (as this PR already includes the fix).

2. It seems that other library classes need no fixes for XP because there were no related style changes.
3. ResizableComboBox example's solution had the library project as the first entry and thus the startup project.

More points for your consideration (not implemented here).
4. `/EDITANDCONTINUE` generates warnings (because of `/SAFESEH`) and could be removed from all projects. 
5. VS 2019 obsoletes  `Enable minimal rebuild` and outputs warnings. The suggestion is to remove it from all projects.
6. ResizableSplitterWnd class has size tracking, but it was not used in your MDI example. It would be nice to be added to the demo.
7. Finally, all examples but one use the name `demo.sln` - tough to choose in Visual Studio from half a dozen of identical names.