### PR TITLE
Remove definition of the standard anchors from the header file.

### DIFF
--- a/ResizableLib/ResizableDialog.cpp
+++ b/ResizableLib/ResizableDialog.cpp
@@ -69,7 +69,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CResizableDialog message handlers
 
-BOOL CResizableDialog::OnNcCreate(LPCREATESTRUCT lpCreateStruct) 
+BOOL CResizableDialog::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 {
 	if (!CDialog::OnNcCreate(lpCreateStruct))
 		return FALSE;
@@ -90,11 +90,11 @@ BOOL CResizableDialog::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 		// set the initial size as the min track size
 		SetMinTrackSize(CSize(lpCreateStruct->cx, lpCreateStruct->cy));
 	}
-	
+
 	return TRUE;
 }
 
-void CResizableDialog::OnDestroy() 
+void CResizableDialog::OnDestroy()
 {
 	if (m_bEnableSaveRestore)
 		SaveWindowRect(m_sSection, m_bRectOnly);
@@ -107,10 +107,10 @@ void CResizableDialog::OnDestroy()
 	CDialog::OnDestroy();
 }
 
-void CResizableDialog::OnSize(UINT nType, int cx, int cy) 
+void CResizableDialog::OnSize(UINT nType, int cx, int cy)
 {
 	CDialog::OnSize(nType, cx, cy);
-	
+
 	if (nType == SIZE_MAXHIDE || nType == SIZE_MAXSHOW)
 		return;		// arrangement not needed
 
@@ -124,7 +124,7 @@ void CResizableDialog::OnSize(UINT nType, int cx, int cy)
 	ArrangeLayout();
 }
 
-void CResizableDialog::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI) 
+void CResizableDialog::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	MinMaxInfo(lpMMI);
 }
@@ -142,7 +142,7 @@ void CResizableDialog::EnableSaveRestore(LPCTSTR pszSection, BOOL bRectOnly)
 	LoadWindowRect(pszSection, bRectOnly);
 }
 
-BOOL CResizableDialog::OnEraseBkgnd(CDC* pDC) 
+BOOL CResizableDialog::OnEraseBkgnd(CDC* pDC)
 {
 	ClipChildren(pDC, FALSE);
 
@@ -153,7 +153,7 @@ BOOL CResizableDialog::OnEraseBkgnd(CDC* pDC)
 	return bRet;
 }
 
-LRESULT CResizableDialog::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) 
+LRESULT CResizableDialog::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message != WM_NCCALCSIZE || wParam == 0)
 		return CDialog::WindowProc(message, wParam, lParam);

--- a/ResizableLib/ResizableFormView.cpp
+++ b/ResizableLib/ResizableFormView.cpp
@@ -79,7 +79,7 @@ void CResizableFormView::Dump(CDumpContext& dc) const
 /////////////////////////////////////////////////////////////////////////////
 // CResizableFormView message handlers
 
-void CResizableFormView::OnSize(UINT nType, int cx, int cy) 
+void CResizableFormView::OnSize(UINT nType, int cx, int cy)
 {
 	CFormView::OnSize(nType, cx, cy);
 
@@ -151,7 +151,7 @@ void CResizableFormView::GetTotalClientRect(LPRECT lpRect) const
 	*lpRect = rect;
 }
 
-BOOL CResizableFormView::OnEraseBkgnd(CDC* pDC) 
+BOOL CResizableFormView::OnEraseBkgnd(CDC* pDC)
 {
 	ClipChildren(pDC, FALSE);
 
@@ -162,12 +162,12 @@ BOOL CResizableFormView::OnEraseBkgnd(CDC* pDC)
 	return bRet;
 }
 
-void CResizableFormView::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI) 
+void CResizableFormView::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	MinMaxInfo(lpMMI);
 }
 
-void CResizableFormView::OnDestroy() 
+void CResizableFormView::OnDestroy()
 {
 	// reset instance data
 	RemoveAllAnchors();
@@ -177,7 +177,7 @@ void CResizableFormView::OnDestroy()
 	CFormView::OnDestroy();
 }
 
-LRESULT CResizableFormView::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) 
+LRESULT CResizableFormView::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message == WM_INITDIALOG)
 		return static_cast<LRESULT>(OnInitDialog());
@@ -193,7 +193,7 @@ LRESULT CResizableFormView::WindowProc(UINT message, WPARAM wParam, LPARAM lPara
 	return lResult;
 }
 
-BOOL CResizableFormView::OnInitDialog() 
+BOOL CResizableFormView::OnInitDialog()
 {
 	const MSG* pMsg = GetCurrentMessage();
 
@@ -201,7 +201,7 @@ BOOL CResizableFormView::OnInitDialog()
 
 	// we need to associate member variables with control IDs
 	UpdateData(FALSE);
-	
+
 	// set default scroll size
 	CRect rectTemplate;
 	GetWindowRect(rectTemplate);
@@ -210,7 +210,7 @@ BOOL CResizableFormView::OnInitDialog()
 	return bRet;
 }
 
-BOOL CResizableFormView::OnNcCreate(LPCREATESTRUCT lpCreateStruct) 
+BOOL CResizableFormView::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 {
 	return CFormView::OnNcCreate(lpCreateStruct) && CreateSizeGrip();	// create and init the size-grip
 }

--- a/ResizableLib/ResizableFormView.h
+++ b/ResizableLib/ResizableFormView.h
@@ -32,7 +32,7 @@
 #include <afxext.h>
 
 class CResizableFormView : public CFormView, public CResizableLayout,
-						 public CResizableGrip, public CResizableMinMax
+						   public CResizableGrip, public CResizableMinMax
 {
 	DECLARE_DYNAMIC(CResizableFormView)
 
@@ -74,6 +74,7 @@ public:
 
 // Overrides
 public:
+	virtual BOOL OnInitDialog();
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CResizableFormView)
 	protected:
@@ -94,7 +95,6 @@ protected:
 	afx_msg BOOL OnEraseBkgnd(CDC* pDC);
 	afx_msg void OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI);
 	afx_msg void OnDestroy();
-	virtual BOOL OnInitDialog();
 	afx_msg BOOL OnNcCreate(LPCREATESTRUCT lpCreateStruct);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/ResizableLib/ResizableFrame.cpp
+++ b/ResizableLib/ResizableFrame.cpp
@@ -52,7 +52,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CResizableFrame message handlers
 
-void CResizableFrame::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI) 
+void CResizableFrame::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	MinMaxInfo(lpMMI);
 
@@ -76,7 +76,7 @@ BOOL CResizableFrame::EnableSaveRestore(LPCTSTR pszSection, BOOL bRectOnly)
 	return LoadWindowRect(pszSection, bRectOnly);
 }
 
-void CResizableFrame::OnDestroy() 
+void CResizableFrame::OnDestroy()
 {
 	if (m_bEnableSaveRestore)
 		SaveWindowRect(m_sSection, m_bRectOnly);
@@ -89,7 +89,7 @@ void CResizableFrame::OnDestroy()
 	CFrameWnd::OnDestroy();
 }
 
-BOOL CResizableFrame::OnNcCreate(LPCREATESTRUCT lpCreateStruct) 
+BOOL CResizableFrame::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 {
 	if (!CFrameWnd::OnNcCreate(lpCreateStruct))
 		return FALSE;
@@ -99,7 +99,7 @@ BOOL CResizableFrame::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 	return TRUE;
 }
 
-LRESULT CResizableFrame::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) 
+LRESULT CResizableFrame::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message != WM_NCCALCSIZE || wParam == 0)
 		return CFrameWnd::WindowProc(message, wParam, lParam);
@@ -114,7 +114,7 @@ LRESULT CResizableFrame::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 
 // TODO: implement this in CResizableMinMax
 // We definitely need pluggable message handlers ala WTL!
-void CResizableFrame::OnWindowPosChanging(WINDOWPOS FAR* lpwndpos) 
+void CResizableFrame::OnWindowPosChanging(WINDOWPOS FAR* lpwndpos)
 {
 	if ((lpwndpos->flags & (SWP_NOSIZE|SWP_NOMOVE)) != (SWP_NOSIZE|SWP_NOMOVE))
 		CFrameWnd::OnWindowPosChanging(lpwndpos);

--- a/ResizableLib/ResizableLayout.cpp
+++ b/ResizableLib/ResizableLayout.cpp
@@ -29,6 +29,19 @@ static char THIS_FILE[]=__FILE__;
 #endif
 
 /*!
+ *  Definition of the standard anchors
+ */
+const ANCHOR TOP_LEFT(0, 0);
+const ANCHOR TOP_CENTER(50, 0);
+const ANCHOR TOP_RIGHT(100, 0);
+const ANCHOR MIDDLE_LEFT(0, 50);
+const ANCHOR MIDDLE_CENTER(50, 50);
+const ANCHOR MIDDLE_RIGHT(100, 50);
+const ANCHOR BOTTOM_LEFT(0, 100);
+const ANCHOR BOTTOM_CENTER(50, 100);
+const ANCHOR BOTTOM_RIGHT(100, 100);
+
+/*!
  *  @internal Constant used to detect clipping and refresh properties
  *
  *  @note In August 2002 Platform SDK, some guy at MS thought it was time
@@ -350,7 +363,7 @@ void CResizableLayout::GetClippingRegion(CRgn* pRegion) const
 		if (::IsWindowVisible(layout.hWnd))
 			ClipChildWindow(layout, pRegion);
 	}
-	
+
 	for (POSITION pos = m_listLayoutCB.GetHeadPosition(); pos != NULL;)
 	{
 		// get layout info
@@ -599,7 +612,7 @@ BOOL CResizableLayout::LikesClipping(const LAYOUTINFO& layout) const
 			return clipping.bLikesClipping;
 	}
 
-	LONG_PTR style = ::GetWindowLongPtr(layout.hWnd, GWL_STYLE);
+	const LONG_PTR style = ::GetWindowLongPtr(layout.hWnd, GWL_STYLE);
 
 	// skip windows that wants background repainted
 	if (0 == lstrcmp(layout.sWndClass, WC_BUTTON))
@@ -727,10 +740,10 @@ BOOL CResizableLayout::GetAnchorMargins(HWND hWnd, const CSize &sizeChild, CRect
 	const LAYOUTINFO& layout = m_listLayout.GetAt(pos);
 
 	// augmented size, relative to anchor points
-	CSize size = sizeChild + layout.marginTopLeft - layout.marginBottomRight;
+	const CSize size = sizeChild + layout.marginTopLeft - layout.marginBottomRight;
 
 	// percent of parent size occupied by this control
-	CSize percent(layout.anchorBottomRight.cx - layout.anchorTopLeft.cx,
+	const CSize percent(layout.anchorBottomRight.cx - layout.anchorTopLeft.cx,
 		layout.anchorBottomRight.cy - layout.anchorTopLeft.cy);
 
 	// calculate total margins

--- a/ResizableLib/ResizableLayout.h
+++ b/ResizableLib/ResizableLayout.h
@@ -54,27 +54,27 @@ typedef struct tagANCHOR
 } ANCHOR, *PANCHOR, *LPANCHOR;
 
 /*! @defgroup ConstAnchors Alignment Constants
- *  Define common layout alignment constants for anchor points.
+ *  Declare common layout alignment constants for anchor points.
  *  @{
  */
 	//! Anchor to the top-left corner
-	const ANCHOR TOP_LEFT(0, 0);
+	extern const ANCHOR TOP_LEFT;
 	//! Anchor to the top edge and center horizontally
-	const ANCHOR TOP_CENTER(50, 0);
+	extern const ANCHOR TOP_CENTER;
 	//! Anchor to the top-right corner
-	const ANCHOR TOP_RIGHT(100, 0);
+	extern const ANCHOR TOP_RIGHT;
 	//! Anchor to the left edge and center vertically
-	const ANCHOR MIDDLE_LEFT(0, 50);
+	extern const ANCHOR MIDDLE_LEFT;
 	//! Anchor to the center
-	const ANCHOR MIDDLE_CENTER(50, 50);
+	extern const ANCHOR MIDDLE_CENTER;
 	//! Anchor to the right edge and center vertically
-	const ANCHOR MIDDLE_RIGHT(100, 50);
+	extern const ANCHOR MIDDLE_RIGHT;
 	//! Anchor to the bottom-left corner
-	const ANCHOR BOTTOM_LEFT(0, 100);
+	extern const ANCHOR BOTTOM_LEFT;
 	//! Anchor to the bottom edge and center horizontally
-	const ANCHOR BOTTOM_CENTER(50, 100);
+	extern const ANCHOR BOTTOM_CENTER;
 	//! Anchor to the bottom-right corner
-	const ANCHOR BOTTOM_RIGHT(100, 100);
+	extern const ANCHOR BOTTOM_RIGHT;
 // @}
 
 //! @brief Holds a control layout settings
@@ -207,7 +207,7 @@ protected:
 	//@{
 	//! @brief Add anchor points for all the remaining controls to the layout
 	void AddAllOtherAnchors(ANCHOR anchorTopLeft, ANCHOR anchorBottomRight);
-	
+
 	void AddAllOtherAnchors(ANCHOR anchor)
 	{
 		AddAllOtherAnchors(anchor, anchor);

--- a/ResizableLib/ResizableMDIChild.cpp
+++ b/ResizableLib/ResizableMDIChild.cpp
@@ -52,7 +52,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CResizableMDIChild message handlers
 
-void CResizableMDIChild::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI) 
+void CResizableMDIChild::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	// MDI should call default implementation
 	CMDIChildWnd::OnGetMinMaxInfo(lpMMI);
@@ -64,7 +64,7 @@ void CResizableMDIChild::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 		ChainMinMaxInfo(lpMMI, this, pView);
 }
 
-void CResizableMDIChild::OnSize(UINT nType, int cx, int cy) 
+void CResizableMDIChild::OnSize(UINT nType, int cx, int cy)
 {
 	CMDIChildWnd::OnSize(nType, cx, cy);
 
@@ -96,7 +96,7 @@ BOOL CResizableMDIChild::EnableSaveRestore(LPCTSTR pszSection, BOOL bRectOnly)
 	return LoadWindowRect(pszSection, bRectOnly);
 }
 
-void CResizableMDIChild::OnDestroy() 
+void CResizableMDIChild::OnDestroy()
 {
 	if (m_bEnableSaveRestore)
 		SaveWindowRect(m_sSection, m_bRectOnly);
@@ -110,7 +110,7 @@ void CResizableMDIChild::OnDestroy()
 }
 
 
-LRESULT CResizableMDIChild::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) 
+LRESULT CResizableMDIChild::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message != WM_NCCALCSIZE || wParam == 0)
 		return CMDIChildWnd::WindowProc(message, wParam, lParam);
@@ -123,7 +123,7 @@ LRESULT CResizableMDIChild::WindowProc(UINT message, WPARAM wParam, LPARAM lPara
 	return lResult;
 }
 
-BOOL CResizableMDIChild::OnNcCreate(LPCREATESTRUCT lpCreateStruct) 
+BOOL CResizableMDIChild::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 {
 	if (!CMDIChildWnd::OnNcCreate(lpCreateStruct))
 		return FALSE;

--- a/ResizableLib/ResizableMDIFrame.cpp
+++ b/ResizableLib/ResizableMDIFrame.cpp
@@ -52,7 +52,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CResizableMDIFrame message handlers
 
-void CResizableMDIFrame::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI) 
+void CResizableMDIFrame::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	// MDI should call default implementation
 	CMDIFrameWnd::OnGetMinMaxInfo(lpMMI);
@@ -78,7 +78,7 @@ BOOL CResizableMDIFrame::EnableSaveRestore(LPCTSTR pszSection, BOOL bRectOnly)
 	return LoadWindowRect(pszSection, bRectOnly);
 }
 
-void CResizableMDIFrame::OnDestroy() 
+void CResizableMDIFrame::OnDestroy()
 {
 	if (m_bEnableSaveRestore)
 		SaveWindowRect(m_sSection, m_bRectOnly);
@@ -91,17 +91,17 @@ void CResizableMDIFrame::OnDestroy()
 	CMDIFrameWnd::OnDestroy();
 }
 
-BOOL CResizableMDIFrame::OnNcCreate(LPCREATESTRUCT lpCreateStruct) 
+BOOL CResizableMDIFrame::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 {
 	if (!CMDIFrameWnd::OnNcCreate(lpCreateStruct))
 		return FALSE;
 
 	MakeResizable(lpCreateStruct);
-	
+
 	return TRUE;
 }
 
-LRESULT CResizableMDIFrame::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) 
+LRESULT CResizableMDIFrame::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message != WM_NCCALCSIZE || wParam == 0)
 		return CMDIFrameWnd::WindowProc(message, wParam, lParam);
@@ -114,7 +114,7 @@ LRESULT CResizableMDIFrame::WindowProc(UINT message, WPARAM wParam, LPARAM lPara
 	return lResult;
 }
 
-void CResizableMDIFrame::OnWindowPosChanging(WINDOWPOS FAR* lpwndpos) 
+void CResizableMDIFrame::OnWindowPosChanging(WINDOWPOS FAR* lpwndpos)
 {
 	CMDIFrameWnd::OnWindowPosChanging(lpwndpos);
 

--- a/ResizableLib/ResizablePage.cpp
+++ b/ResizableLib/ResizablePage.cpp
@@ -61,14 +61,14 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CResizablePage message handlers
 
-void CResizablePage::OnSize(UINT nType, int cx, int cy) 
+void CResizablePage::OnSize(UINT nType, int cx, int cy)
 {
 	CWnd::OnSize(nType, cx, cy);
-	
+
 	ArrangeLayout();
 }
 
-BOOL CResizablePage::OnEraseBkgnd(CDC* pDC) 
+BOOL CResizablePage::OnEraseBkgnd(CDC* pDC)
 {
 	ClipChildren(pDC, FALSE);
 
@@ -79,25 +79,25 @@ BOOL CResizablePage::OnEraseBkgnd(CDC* pDC)
 	return bRet;
 }
 
-void CResizablePage::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI) 
+void CResizablePage::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	MinMaxInfo(lpMMI);
 }
 
-BOOL CResizablePage::OnInitDialog() 
+BOOL CResizablePage::OnInitDialog()
 {
 	CPropertyPage::OnInitDialog();
-	
+
 	// set the initial size as the min track size
 	CRect rc;
 	GetWindowRect(&rc);
 	SetMinTrackSize(rc.Size());
 
-	return TRUE;  // return TRUE unless you set the focus to a control
-	              // EXCEPTION: OCX Property Pages should return FALSE
+	return TRUE; // return TRUE unless you set the focus to a control
+				 // EXCEPTION: OCX Property Pages should return FALSE
 }
 
-void CResizablePage::OnDestroy() 
+void CResizablePage::OnDestroy()
 {
 	// remove child windows
 	RemoveAllAnchors();
@@ -106,7 +106,7 @@ void CResizablePage::OnDestroy()
 	CPropertyPage::OnDestroy();
 }
 
-LRESULT CResizablePage::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) 
+LRESULT CResizablePage::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message != WM_NCCALCSIZE || wParam == 0)
 		return CPropertyPage::WindowProc(message, wParam, lParam);

--- a/ResizableLib/ResizablePage.h
+++ b/ResizableLib/ResizablePage.h
@@ -40,15 +40,14 @@ public:
 	explicit CResizablePage(LPCTSTR lpszTemplateName, UINT nIDCaption = 0);
 
 // Attributes
-public:
 
 // Operations
-public:
 
 // Overrides
+	virtual BOOL OnInitDialog();
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CResizablePage)
-	protected:
+protected:
 	virtual LRESULT WindowProc(UINT message, WPARAM wParam, LPARAM lParam);
 	//}}AFX_VIRTUAL
 
@@ -66,12 +65,10 @@ protected:
 	};
 
 // Generated message map functions
-protected:
 	//{{AFX_MSG(CResizablePage)
 	afx_msg void OnSize(UINT nType, int cx, int cy);
 	afx_msg BOOL OnEraseBkgnd(CDC* pDC);
 	afx_msg void OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI);
-	virtual BOOL OnInitDialog();
 	afx_msg void OnDestroy();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/ResizableLib/ResizablePageEx.cpp
+++ b/ResizableLib/ResizablePageEx.cpp
@@ -62,17 +62,17 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CResizablePageEx message handlers
 
-void CResizablePageEx::OnSize(UINT nType, int cx, int cy) 
+void CResizablePageEx::OnSize(UINT nType, int cx, int cy)
 {
 	CWnd::OnSize(nType, cx, cy);
-	
+
 	ArrangeLayout();
 
 	if (m_psp.dwFlags & PSP_HIDEHEADER)
 		Invalidate();
 }
 
-BOOL CResizablePageEx::OnEraseBkgnd(CDC* pDC) 
+BOOL CResizablePageEx::OnEraseBkgnd(CDC* pDC)
 {
 	ClipChildren(pDC, FALSE);
 
@@ -83,15 +83,15 @@ BOOL CResizablePageEx::OnEraseBkgnd(CDC* pDC)
 	return bRet;
 }
 
-void CResizablePageEx::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI) 
+void CResizablePageEx::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	MinMaxInfo(lpMMI);
 }
 
-BOOL CResizablePageEx::OnInitDialog() 
+BOOL CResizablePageEx::OnInitDialog()
 {
 	CPropertyPageEx::OnInitDialog();
-	
+
 	// set the initial size as the min track size
 	CRect rc;
 	GetWindowRect(&rc);
@@ -108,11 +108,11 @@ BOOL CResizablePageEx::OnInitDialog()
 		Post_SheetPageExHack(pParent->GetSafeHwnd(), m_hWnd);
 	}
 
-	return TRUE;  // return TRUE unless you set the focus to a control
-	              // EXCEPTION: OCX Property Pages should return FALSE
+	return TRUE; // return TRUE unless you set the focus to a control
+				 // EXCEPTION: OCX Property Pages should return FALSE
 }
 
-void CResizablePageEx::OnDestroy() 
+void CResizablePageEx::OnDestroy()
 {
 	// remove child windows
 	RemoveAllAnchors();
@@ -121,7 +121,7 @@ void CResizablePageEx::OnDestroy()
 	CPropertyPageEx::OnDestroy();
 }
 
-HBRUSH CResizablePageEx::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor) 
+HBRUSH CResizablePageEx::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
 	// NOTE: this message couldn't be catched without the above hack
 
@@ -144,7 +144,7 @@ HBRUSH CResizablePageEx::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 	return hbr;
 }
 
-LRESULT CResizablePageEx::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) 
+LRESULT CResizablePageEx::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message != WM_NCCALCSIZE || wParam == 0)
 		return CPropertyPageEx::WindowProc(message, wParam, lParam);

--- a/ResizableLib/ResizablePageEx.h
+++ b/ResizableLib/ResizablePageEx.h
@@ -46,6 +46,7 @@ public:
 public:
 
 // Overrides
+	virtual BOOL OnInitDialog();
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CResizablePageEx)
 	protected:
@@ -71,7 +72,6 @@ protected:
 	afx_msg void OnSize(UINT nType, int cx, int cy);
 	afx_msg BOOL OnEraseBkgnd(CDC* pDC);
 	afx_msg void OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI);
-	virtual BOOL OnInitDialog();
 	afx_msg void OnDestroy();
 	afx_msg HBRUSH OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor);
 	//}}AFX_MSG

--- a/ResizableLib/ResizableSheet.cpp
+++ b/ResizableLib/ResizableSheet.cpp
@@ -50,13 +50,13 @@ CResizableSheet::CResizableSheet()
 }
 
 CResizableSheet::CResizableSheet(UINT nIDCaption, CWnd *pParentWnd, UINT iSelectPage)
-	 : CPropertySheet(nIDCaption, pParentWnd, iSelectPage)
+	: CPropertySheet(nIDCaption, pParentWnd, iSelectPage)
 {
 	PrivateConstruct();
 }
 
 CResizableSheet::CResizableSheet(LPCTSTR pszCaption, CWnd *pParentWnd, UINT iSelectPage)
-	 : CPropertySheet(pszCaption, pParentWnd, iSelectPage)
+	: CPropertySheet(pszCaption, pParentWnd, iSelectPage)
 {
 	PrivateConstruct();
 }
@@ -79,7 +79,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CResizableSheet message handlers
 
-BOOL CResizableSheet::OnNcCreate(LPCREATESTRUCT lpCreateStruct) 
+BOOL CResizableSheet::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 {
 	if (!CPropertySheet::OnNcCreate(lpCreateStruct))
 		return FALSE;
@@ -93,11 +93,11 @@ BOOL CResizableSheet::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 		return FALSE;
 
 	MakeResizable(lpCreateStruct);
-	
+
 	return TRUE;
 }
 
-BOOL CResizableSheet::OnInitDialog() 
+BOOL CResizableSheet::OnInitDialog()
 {
 	BOOL bResult = CPropertySheet::OnInitDialog();
 
@@ -108,7 +108,7 @@ BOOL CResizableSheet::OnInitDialog()
 	return bResult;
 }
 
-void CResizableSheet::OnDestroy() 
+void CResizableSheet::OnDestroy()
 {
 	if (m_bEnableSaveRestore)
 	{
@@ -220,7 +220,7 @@ void CResizableSheet::PresetLayout()
 		// grow tab to the available sheet space
 		if (cyDiff > 0)
 			rectSheet.bottom = rectPage.bottom + cyDiff;
-		
+
 		if (GetStyle() & WS_CHILD)
 			GetTabControl()->MoveWindow(&rectSheet);
 
@@ -286,10 +286,10 @@ BOOL CResizableSheet::ArrangeLayoutCallback(LAYOUTINFO &layout) const
 	return TRUE;
 }
 
-void CResizableSheet::OnSize(UINT nType, int cx, int cy) 
+void CResizableSheet::OnSize(UINT nType, int cx, int cy)
 {
 	CWnd::OnSize(nType, cx, cy);
-	
+
 	if (nType == SIZE_MAXHIDE || nType == SIZE_MAXSHOW)
 		return;		// arrangement not needed
 
@@ -312,7 +312,7 @@ BOOL CResizableSheet::OnPageChanging(NMHDR* /*pNotifyStruct*/, LRESULT* /*pResul
 	return FALSE;	// continue routing
 }
 
-BOOL CResizableSheet::OnEraseBkgnd(CDC* pDC) 
+BOOL CResizableSheet::OnEraseBkgnd(CDC* pDC)
 {
 	ClipChildren(pDC, FALSE);
 
@@ -361,7 +361,7 @@ BOOL CResizableSheet::CalcSizeExtra(HWND /*hWndChild*/, const CSize& sizeChild, 
 	return TRUE;
 }
 
-void CResizableSheet::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI) 
+void CResizableSheet::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	MinMaxInfo(lpMMI);
 
@@ -406,7 +406,7 @@ int CResizableSheet::GetMinWidth()
 			::MapWindowPoints(NULL, m_hWnd, (LPPOINT)&rectWnd, 2);
 			const int left = rectSheet.right - rectWnd.left;
 			const int right = rectSheet.right - rectWnd.right;
-	
+
 			if (left > max)
 				max = left;
 			if (right < min)
@@ -416,7 +416,7 @@ int CResizableSheet::GetMinWidth()
 
 	// sizing border width
 	const int border = GetSystemMetrics(SM_CXSIZEFRAME);
-	
+
 	// compute total width
 	return max + min + 2*border;
 }
@@ -445,7 +445,7 @@ void CResizableSheet::RefreshLayout()
 	SendMessage(WM_SIZE);
 }
 
-LRESULT CResizableSheet::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) 
+LRESULT CResizableSheet::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message != WM_NCCALCSIZE || wParam == 0 || !m_bLayoutDone)
 		return CPropertySheet::WindowProc(message, wParam, lParam);

--- a/ResizableLib/ResizableSheet.h
+++ b/ResizableLib/ResizableSheet.h
@@ -63,10 +63,9 @@ private:
 public:
 
 // Overrides
+	virtual BOOL OnInitDialog();
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CResizableSheet)
-	public:
-	virtual BOOL OnInitDialog();
 	protected:
 	virtual LRESULT WindowProc(UINT message, WPARAM wParam, LPARAM lParam);
 	//}}AFX_VIRTUAL

--- a/ResizableLib/ResizableSheetEx.cpp
+++ b/ResizableLib/ResizableSheetEx.cpp
@@ -59,7 +59,7 @@ CResizableSheetEx::CResizableSheetEx(UINT nIDCaption, CWnd* pParentWnd,
 	UINT iSelectPage, HBITMAP hbmWatermark, HPALETTE hpalWatermark,
 	HBITMAP hbmHeader)
 : CPropertySheetEx(nIDCaption, pParentWnd, iSelectPage,
-				  hbmWatermark, hpalWatermark, hbmHeader)
+				   hbmWatermark, hpalWatermark, hbmHeader)
 {
 	PrivateConstruct();
 }
@@ -68,7 +68,7 @@ CResizableSheetEx::CResizableSheetEx(LPCTSTR pszCaption, CWnd* pParentWnd,
 	UINT iSelectPage, HBITMAP hbmWatermark, HPALETTE hpalWatermark,
 	HBITMAP hbmHeader)
 : CPropertySheetEx(pszCaption, pParentWnd, iSelectPage,
-					  hbmWatermark, hpalWatermark, hbmHeader)
+				   hbmWatermark, hpalWatermark, hbmHeader)
 {
 	PrivateConstruct();
 }
@@ -93,7 +93,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CResizableSheetEx message handlers
 
-BOOL CResizableSheetEx::OnNcCreate(LPCREATESTRUCT lpCreateStruct) 
+BOOL CResizableSheetEx::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 {
 	if (!CPropertySheetEx::OnNcCreate(lpCreateStruct))
 		return FALSE;
@@ -107,14 +107,14 @@ BOOL CResizableSheetEx::OnNcCreate(LPCREATESTRUCT lpCreateStruct)
 		return FALSE;
 
 	MakeResizable(lpCreateStruct);
-	
+
 	return TRUE;
 }
 
-BOOL CResizableSheetEx::OnInitDialog() 
+BOOL CResizableSheetEx::OnInitDialog()
 {
 	const BOOL bResult = CPropertySheetEx::OnInitDialog();
-	
+
 	// initialize layout
 	PresetLayout();
 	m_bLayoutDone = TRUE;
@@ -158,7 +158,7 @@ LRESULT CResizableSheetEx::OnResizeSupport(WPARAM wParam, LPARAM lParam)
 	return TRUE;
 }
 
-void CResizableSheetEx::OnDestroy() 
+void CResizableSheetEx::OnDestroy()
 {
 	if (m_bEnableSaveRestore)
 	{
@@ -274,7 +274,7 @@ void CResizableSheetEx::PresetLayout()
 		// grow tab to the available sheet space
 		if (cyDiff > 0)
 			rectSheet.bottom = rectPage.bottom + cyDiff;
-		
+
 		if (GetStyle() & WS_CHILD)
 			GetTabControl()->MoveWindow(&rectSheet);
 
@@ -356,10 +356,10 @@ BOOL CResizableSheetEx::ArrangeLayoutCallback(LAYOUTINFO &layout) const
 	return TRUE;
 }
 
-void CResizableSheetEx::OnSize(UINT nType, int cx, int cy) 
+void CResizableSheetEx::OnSize(UINT nType, int cx, int cy)
 {
 	CWnd::OnSize(nType, cx, cy);
-	
+
 	if (nType == SIZE_MAXHIDE || nType == SIZE_MAXSHOW)
 		return;		// arrangement not needed
 
@@ -390,7 +390,7 @@ BOOL CResizableSheetEx::OnPageChanging(NMHDR* /*pNotifyStruct*/, LRESULT* /*pRes
 	return FALSE;	// continue routing
 }
 
-BOOL CResizableSheetEx::OnEraseBkgnd(CDC* pDC) 
+BOOL CResizableSheetEx::OnEraseBkgnd(CDC* pDC)
 {
 	CRect rect;
 	if (m_psh.dwFlags & PSH_IE4WIZARD97)
@@ -582,7 +582,7 @@ int CResizableSheetEx::GetMinWidth()
 			::MapWindowPoints(NULL, m_hWnd, (LPPOINT)&rectWnd, 2);
 			const int left = rectSheet.right - rectWnd.left;
 			const int right = rectSheet.right - rectWnd.right;
-			
+
 			if (left > max)
 				max = left;
 			if (right < min)
@@ -592,7 +592,7 @@ int CResizableSheetEx::GetMinWidth()
 
 	// sizing border width
 	const int border = GetSystemMetrics(SM_CXSIZEFRAME);
-	
+
 	// compute total width
 	return max + min + 2*border;
 }
@@ -621,7 +621,7 @@ void CResizableSheetEx::RefreshLayout()
 	SendMessage(WM_SIZE);
 }
 
-LRESULT CResizableSheetEx::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) 
+LRESULT CResizableSheetEx::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message != WM_NCCALCSIZE || wParam == 0 || !m_bLayoutDone)
 		return CPropertySheetEx::WindowProc(message, wParam, lParam);

--- a/ResizableLib/ResizableSheetEx.h
+++ b/ResizableLib/ResizableSheetEx.h
@@ -70,10 +70,9 @@ public:
 	};
 
 // Overrides
+	virtual BOOL OnInitDialog();
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CResizableSheetEx)
-	public:
-	virtual BOOL OnInitDialog();
 	protected:
 	virtual LRESULT WindowProc(UINT message, WPARAM wParam, LPARAM lParam);
 	//}}AFX_VIRTUAL

--- a/ResizableLib/ResizableSheetState.cpp
+++ b/ResizableLib/ResizableSheetState.cpp
@@ -39,15 +39,15 @@ CResizableSheetState::~CResizableSheetState()
 // either in the registry or a private .INI file
 // depending on your application settings
 
-#define ACTIVEPAGE_ENT 	_T("ActivePage")
+#define ACTIVEPAGE_ENT	_T("ActivePage")
 
 /*!
  *  This function saves the current property sheet active page using the base
  *  class persist method.
  *  @sa CResizableState::WriteState
- *  
+ *
  *  @param pszName String that identifies stored settings
- *  
+ *
  *  @return Returns @a TRUE if successful, @a FALSE otherwise
  */
 BOOL CResizableSheetState::SavePage(LPCTSTR pszName)
@@ -59,10 +59,9 @@ BOOL CResizableSheetState::SavePage(LPCTSTR pszName)
 	if (pSheet == NULL)
 		return FALSE;
 
-	int page = pSheet->m_psh.nStartPage;
 	const CTabCtrl *pTab = pSheet->GetTabControl();
-	if (pTab != NULL) 
-		page = pTab->GetCurSel();
+	int page = (pTab != NULL) ? pTab->GetCurSel() : pSheet->m_psh.nStartPage;
+
 	if (page < 0)
 		page = pSheet->m_psh.nStartPage;
 
@@ -75,9 +74,9 @@ BOOL CResizableSheetState::SavePage(LPCTSTR pszName)
 /*!
  *  This function loads the active page using the base class persist method.
  *  @sa CResizableState::ReadState
- *  
+ *
  *  @param pszName String that identifies stored settings
- *  
+ *
  *  @return Returns @a TRUE if successful, @a FALSE otherwise
  */
 BOOL CResizableSheetState::LoadPage(LPCTSTR pszName)
@@ -87,7 +86,7 @@ BOOL CResizableSheetState::LoadPage(LPCTSTR pszName)
 	CString data;
 	if (!ReadState(CString(pszName) + ACTIVEPAGE_ENT, data))
 		return FALSE;
-	
+
 	CPropertySheet* pSheet = DYNAMIC_DOWNCAST(CPropertySheet, GetResizableWnd());
 
 	return (pSheet != NULL) && pSheet->SetActivePage(_ttoi(data));

--- a/ResizableLib/ResizableSheetState.h
+++ b/ResizableLib/ResizableSheetState.h
@@ -38,14 +38,14 @@
  *  This class is used in the provided resizable counterparts of
  *  the standard MFC property sheet classes.
  */
-class CResizableSheetState : public CResizableWndState  
+class CResizableSheetState : public CResizableWndState
 {
 protected:
 
-	//! @brief Load and set the active property page 
+	//! @brief Load and set the active property page
 	BOOL LoadPage(LPCTSTR pszName);
 
-	//! @brief Save the current active property page 
+	//! @brief Save the current active property page
 	BOOL SavePage(LPCTSTR pszName);
 
 	//! @brief Override to provide the parent window

--- a/ResizableLib/ResizableSplitterWnd.cpp
+++ b/ResizableLib/ResizableSplitterWnd.cpp
@@ -46,7 +46,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CResizableSplitterWnd message handlers
 
-void CResizableSplitterWnd::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI) 
+void CResizableSplitterWnd::OnGetMinMaxInfo(MINMAXINFO FAR* lpMMI)
 {
 	if ((GetStyle() & SPLS_DYNAMIC_SPLIT) &&
 		GetRowCount() == 1 && GetColumnCount() == 1)

--- a/ResizableLib/ResizableVersion.cpp
+++ b/ResizableLib/ResizableVersion.cpp
@@ -53,7 +53,7 @@ static DLLVERSIONINFO g_dviCommCtrls;
 static OSVERSIONINFOEX g_osviWindows;
 
 #pragma warning(push)
-#pragma warning(disable:4996) 
+#pragma warning(disable:4996)
 static void CheckOsVersion()
 {
 	// Try calling GetVersionEx using the OSVERSIONINFOEX structure.
@@ -61,7 +61,7 @@ static void CheckOsVersion()
 	g_osviWindows.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
 	if (GetVersionEx((LPOSVERSIONINFO)&g_osviWindows))
 		return;
-	
+
 	// If that fails, try using the OSVERSIONINFO structure.
 	g_osviWindows.dwOSVersionInfoSize = sizeof (OSVERSIONINFO);
 	if (GetVersionEx((LPOSVERSIONINFO)&g_osviWindows))

--- a/ResizableLib/ResizableWndState.cpp
+++ b/ResizableLib/ResizableWndState.cpp
@@ -40,7 +40,7 @@ CResizableWndState::~CResizableWndState()
 // depending on your application settings
 
 #define PLACEMENT_ENT	_T("WindowPlacement")
-#define PLACEMENT_FMT 	_T("%ld,%ld,%ld,%ld,%u,%u,%ld,%ld")
+#define PLACEMENT_FMT	_T("%ld,%ld,%ld,%ld,%u,%u,%ld,%ld")
 
 /*!
  *  This function saves the current window position and size using the base
@@ -57,7 +57,8 @@ CResizableWndState::~CResizableWndState()
  */
 BOOL CResizableWndState::SaveWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 {
-	WINDOWPLACEMENT wp = {sizeof(WINDOWPLACEMENT)};
+	WINDOWPLACEMENT wp;
+	wp.length = sizeof(WINDOWPLACEMENT);
 
 	if (!GetResizableWnd()->GetWindowPlacement(&wp))
 		return FALSE;
@@ -69,7 +70,7 @@ BOOL CResizableWndState::SaveWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 	if (bRectOnly)	// save size/pos only (normal state)
 	{
 		data.Format(PLACEMENT_FMT, rc.left, rc.top,
-			rc.right, rc.bottom, SW_SHOWNORMAL, 0U, 0L, 0L);
+			rc.right, rc.bottom, (unsigned)SW_SHOWNORMAL, 0U, 0L, 0L);
 	}
 	else	// save also min/max state
 	{
@@ -97,7 +98,8 @@ BOOL CResizableWndState::SaveWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 BOOL CResizableWndState::LoadWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 {
 	CString data;
-	WINDOWPLACEMENT wp = {sizeof(WINDOWPLACEMENT)};
+	WINDOWPLACEMENT wp;
+	wp.length = sizeof(WINDOWPLACEMENT);
 
 	if (!ReadState(CString(pszName) + PLACEMENT_ENT, data))	// never saved before
 		return FALSE;

--- a/ResizableLib/ResizableWndState.h
+++ b/ResizableLib/ResizableWndState.h
@@ -7,7 +7,7 @@
 // http://www.geocities.com/ppescher - mailto:ppescher@hotmail.com
 //
 // The contents of this file are subject to the Artistic License (the "License").
-// You may not use this file except in compliance with the License. 
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
 // http://www.opensource.org/licenses/artistic-license.html
 //
@@ -40,7 +40,7 @@
  *  This class is used in the provided resizable counterparts of
  *  the standard MFC window and dialog classes.
  */
-class CResizableWndState : public CResizableState  
+class CResizableWndState : public CResizableState
 {
 protected:
 


### PR DESCRIPTION
Trim trailing whitespace in all library files.