### PR TITLE
allow initial state SW_HIDE

### DIFF
--- a/ResizableLib/ResizableWndState.cpp
+++ b/ResizableLib/ResizableWndState.cpp
@@ -114,9 +114,15 @@ BOOL CResizableWndState::LoadWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 		&rc.right, &rc.bottom, &wp.showCmd, &wp.flags,
 		&wp.ptMinPosition.x, &wp.ptMinPosition.y) == 8)
 	{
+
+		if (!showOnWindowPlacement) {
+			wp.showCmd = SW_HIDE;
+		} else if (bRectOnly) {
+			wp.showCmd = SW_SHOWNORMAL;
+		}
+
 		if (bRectOnly)	// restore size/pos only
 		{
-			wp.showCmd = SW_SHOWNORMAL;
 			wp.flags = 0;
 		}
 		// restore also min/max state

--- a/ResizableLib/ResizableWndState.h
+++ b/ResizableLib/ResizableWndState.h
@@ -44,6 +44,7 @@ class CResizableWndState : public CResizableState
 {
 protected:
 
+	bool showOnWindowPlacement = true;
 	//! @brief Load and set the window position and size
 	BOOL LoadWindowRect(LPCTSTR pszName, BOOL bRectOnly);
 


### PR DESCRIPTION
First proposed patch.  This is used to allow resizelib to work with an initially hidden dialog.  

In ~~2014~~ 2002, `wp.showCmd = SW_SHOWNORMAL` did not exist, but it still showed the dialog initially.

In order to work with latest code, I put that into an else-block so it doesn't override `SW_HIDE`.